### PR TITLE
needs more docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM jess/chrome
+
+ADD . /tirefi.re
+
+WORKDIR /tirefi.re

--- a/docker/docker/docker/docker/docker/docker/docker/docker/docker/docker/index.html
+++ b/docker/docker/docker/docker/docker/docker/docker/docker/docker/docker/index.html
@@ -24,6 +24,7 @@
 <h1>This is a container fire.</h1>
 <p><img src="http://tirefi.re/docker/docker_ship_fire.jpg" alt="You need to burn in hell from whence you've came!" /></a></p>
 <div class="c1"><small>Docker replaces virtualization right....?</small></div>
+<div class="c1"><small>$ docker build -t tirefi/re . && docker/run.sh</small></div>
 <div class="c1"><small>With love, <a href="https://twitter.com/sdmouton/">@sdmouton</a>, <a href="https://twitter.com/jjasghar">@jjasghar</a>, <a href="https://twitter.com/OnlyHaveCans">@OnlyHaveCans</a> and friends!</small></div>
 <p><a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0 Strict" height="31" width="88" /></a></p>
 </body>

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#xhost +
+DIR=$HOME/.chromedocker
+
+docker run --rm -it \
+        --memory 2gb \
+        -v /etc/localtime:/etc/localtime:ro \
+        -v /tmp/.X11-unix:/tmp/.X11-unix \
+        -v $(pwd):/tirefi.re \
+        -e DISPLAY=unix$DISPLAY \
+        --device /dev/snd \
+        --device /dev/dri \
+        --device /dev/video0 \
+        --device /dev/usb \
+        --device /dev/bus/usb \
+        --group-add audio \
+        --group-add video \
+        --privileged \
+        --name tirefire \
+        tirefi/re --user-data-dir=/tmp file:///tirefi.re/docker/docker/docker/docker/docker/docker/docker/docker/docker/docker/index.html
+#xhost -


### PR DESCRIPTION
This adds a chrome docker container that can be used
to view tirefi.re in development.

instructions for using it can be found in tirefi.re/docker

should probably register the tirefi namespace on docker registry
so that we can add it as a trusted build as `tirefi/re`.

it probably only works on linux, but hey, that's kinda the point.
