### PR TITLE
Added dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
@jjasghar Hopefully this is what you are looking for, there are many more configuration options but I wasn't sure what would be preferred. Some useful options may be: `open-pull-requests-limit`, `reviewers`, `assignees` and `target-branch`. Let me know if you want to add options or change the current ones.
Resolves #121. Security alerts can also be enabled from the Security tab of the repo. 